### PR TITLE
Update cvm function

### DIFF
--- a/R/cvm_prioritylasso.R
+++ b/R/cvm_prioritylasso.R
@@ -19,6 +19,7 @@
 #' \item{\code{name}}{a text string indicating type of measure.}
 #' \item{\code{block1unpen}}{if \code{block1.penalization = FALSE}, the results of either the fitted \code{glm} or \code{coxph} object.}
 #' \item{\code{best.blocks}}{character vector with the indices of the best block specification.}
+#' \item{\code{best.blocks.indices}}{list with the indices of the best block specification ordered by best to worst.}
 #' \item{\code{best.max.coef}}{vector with the number of maximal coefficients corresponding to \code{best.blocks}.}
 #' \item{\code{best.model}}{complete \code{prioritylasso} model of the best solution.}
 #' \item{\code{coefficients}}{coefficients according to the results obtained with \code{best.blocks}.}
@@ -96,8 +97,11 @@ cvm_prioritylasso <- function(X,
   bfv <- lapply(best.var, '[[', 1)
   blv <- lapply(best.var, length)
   best.blocks <- vector()
+  best.blocks.indices <- list()
   for(k in 1:length(bfv)){
     best.blocks <- c(best.blocks, paste("bp",k," = ", bfv[[k]],":",blv[[k]] + bfv[[k]] - 1, sep=""))
+    best.blocks.indices[[k]] <- seq(from = bfv[[k]], to = blv[[k]] + bfv[[k]] - 1,
+                                    by = 1)
   }
 
   finallist <- list(lambda.ind = all_res[[ind.best.pr]]$lambda.ind,
@@ -109,6 +113,7 @@ cvm_prioritylasso <- function(X,
                     name = all_res[[ind.best.pr]]$name,
                     block1unpen = all_res[[ind.best.pr]]$block1unpen,
                     best.blocks = best.blocks,
+                    best.blocks.indices = best.blocks.indices,
                     best.max.coef = max.coef.list[[ind.best.pr]],
                     best.model = all_res[[ind.best.pr]],
                     coefficients = all_res[[ind.best.pr]]$coefficients,

--- a/R/cvm_prioritylasso.R
+++ b/R/cvm_prioritylasso.R
@@ -18,9 +18,9 @@
 #' @param cvoffset logical, whether CV should be used to estimate the offsets. Default is FALSE.
 #' @param cvoffsetnfolds the number of folds in the CV procedure that is performed to estimate the offsets. Default is 10. Only relevant if \code{cvoffset=TRUE}.
 
-#' @param ... Other arguments that can be passed to the function \code{cv.glmnet}.
+#' @param ... Other arguments that can be passed to the function \code{prioritylasso}.
 #'
-#' @return object of class \code{prioritylasso} with the following elements. If these elements are lists, they contain the results for each penalized block of the best result.
+#' @return object of class \code{cvm_prioritylasso} with the following elements. If these elements are lists, they contain the results for each penalized block of the best result.
 #' \describe{
 #' \item{\code{lambda.ind}}{list with indices of lambda for \code{lambda.type}.}
 #' \item{\code{lambda.type}}{type of lambda which is used for the predictions.}
@@ -32,6 +32,7 @@
 #' \item{\code{block1unpen}}{if \code{block1.penalization = FALSE}, the results of either the fitted \code{glm} or \code{coxph} object.}
 #' \item{\code{best.blocks}}{character vector with the indices of the best block specification.}
 #' \item{\code{best.max.coef}}{vector with the number of maximal coefficients corresponding to \code{best.blocks}.}
+#' \item{\code{best.model}}{complete \code{prioritylasso} model of the best solution.}
 #' \item{\code{coefficients}}{coefficients according to the results obtained with \code{best.blocks}.}
 #' \item{\code{call}}{the function call.}
 #' }
@@ -99,15 +100,21 @@ cvm_prioritylasso <- function(X, Y, weights, family, type.measure, blocks.list, 
     best.blocks <- c(best.blocks, paste("bp",k," = ", bfv[[k]],":",blv[[k]] + bfv[[k]] - 1, sep=""))
   }
 
-  finallist <- list(lambda.ind = all_res[[ind.best.pr]]$lambda.ind, lambda.type = lambda.type,
+  finallist <- list(lambda.ind = all_res[[ind.best.pr]]$lambda.ind,
+                    lambda.type = lambda.type,
                     lambda.min = all_res[[ind.best.pr]]$lambda.min,
-                    min.cvm = all_res[[ind.best.pr]]$min.cvm, nzero = all_res[[ind.best.pr]]$nzero,
-                    glmnet.fit = all_res[[ind.best.pr]]$glmnet.fit, name = all_res[[ind.best.pr]]$name,
-                    block1unpen = all_res[[ind.best.pr]]$block1unpen, best.blocks = best.blocks,
-                    best.max.coef = max.coef.list[[ind.best.pr]], coefficients = all_res[[ind.best.pr]]$coefficients,
+                    min.cvm = all_res[[ind.best.pr]]$min.cvm,
+                    nzero = all_res[[ind.best.pr]]$nzero,
+                    glmnet.fit = all_res[[ind.best.pr]]$glmnet.fit,
+                    name = all_res[[ind.best.pr]]$name,
+                    block1unpen = all_res[[ind.best.pr]]$block1unpen,
+                    best.blocks = best.blocks,
+                    best.max.coef = max.coef.list[[ind.best.pr]],
+                    best.model = all_res[[ind.best.pr]],
+                    coefficients = all_res[[ind.best.pr]]$coefficients,
                     call = match.call())
 
-  class(finallist) <- "prioritylasso"
+  class(finallist) <- c("cvm_prioritylasso", class(finallist))
 
   return(finallist)
 

--- a/R/cvm_prioritylasso.R
+++ b/R/cvm_prioritylasso.R
@@ -3,22 +3,10 @@
 #' Runs prioritylasso for a list of block specifications and gives the best results
 #' in terms of cv error.
 #'
-#' @param X a (nxp) matrix or data frame of predictors with observations in rows and predictors in columns.
-#' @param Y n-vector giving the value of the response (either continuous, numeric-binary 0/1, or \code{Surv} object).
-#' @param weights observation weights. Default is 1 for each observation.
-#' @param family should be "gaussian" for continuous \code{Y}, "binomial" for binary \code{Y}, "cox" for \code{Y} of type \code{Surv}.
-#' @param type.measure The accuracy/error measure computed in cross-validation. It should be "class" (classification error) or "auc" (area under the ROC curve) if \code{family="binomial"}, "mse" (mean squared error) if \code{family="gaussian"} and "deviance" if \code{family="cox"} which uses the partial-likelihood.
+#' @inheritParams prioritylasso
 #' @param blocks.list list of the format \code{list(list(bp1=...,bp2=...,), list(bp1=,...,bp2=...,), ...)}. For the specification of the entries, see \code{\link[prioritylasso]{prioritylasso}}.
 #' @param max.coef.list list of \code{max.coef} vectors. The first entries are omitted if \code{block1.penalization = FALSE}. Default is \code{NULL}.
-#' @param block1.penalization whether the first block should be penalized. Default is TRUE.
-#' @param lambda.type specifies the value of lambda used for the predictions. \code{lambda.min} gives lambda with minimum cross-validated errors. \code{lambda.1se} gives the largest value of lambda such that error is within 1 standard error of the minimum. Note that \code{lambda.1se} can only be chosen without restrictions of \code{max.coef}.
-#' @param standardize logical, whether the predictors should be standardized or not. Default is TRUE.
-#' @param nfolds the number of CV procedure folds.
-#' @param foldid an optional vector of values between 1 and nfold identifying what fold each observation is in.
-#' @param cvoffset logical, whether CV should be used to estimate the offsets. Default is FALSE.
-#' @param cvoffsetnfolds the number of folds in the CV procedure that is performed to estimate the offsets. Default is 10. Only relevant if \code{cvoffset=TRUE}.
-
-#' @param ... Other arguments that can be passed to the function \code{prioritylasso}.
+#' @param ... other arguments that can be passed to the function \code{prioritylasso}.
 #'
 #' @return object of class \code{cvm_prioritylasso} with the following elements. If these elements are lists, they contain the results for each penalized block of the best result.
 #' \describe{
@@ -57,9 +45,21 @@
 #'
 
 
-cvm_prioritylasso <- function(X, Y, weights, family, type.measure, blocks.list, max.coef.list = NULL,
-                              block1.penalization = TRUE, lambda.type = "lambda.min",
-                              standardize = TRUE, nfolds = 10, foldid, cvoffset = FALSE, cvoffsetnfolds = 10, ...){
+cvm_prioritylasso <- function(X,
+                              Y,
+                              weights,
+                              family,
+                              type.measure,
+                              blocks.list,
+                              max.coef.list = NULL,
+                              block1.penalization = TRUE,
+                              lambda.type = "lambda.min",
+                              standardize = TRUE,
+                              nfolds = 10,
+                              foldid,
+                              cvoffset = FALSE,
+                              cvoffsetnfolds = 10,
+                              ...){
 
   if(!is.null(max.coef.list)){
     if(length(blocks.list) != length(max.coef.list)){stop("blocks.list and max.coef.list must have the same length.")}

--- a/man/cvm_prioritylasso.Rd
+++ b/man/cvm_prioritylasso.Rd
@@ -51,10 +51,10 @@ cvm_prioritylasso(
 
 \item{cvoffsetnfolds}{the number of folds in the CV procedure that is performed to estimate the offsets. Default is 10. Only relevant if \code{cvoffset=TRUE}.}
 
-\item{...}{Other arguments that can be passed to the function \code{cv.glmnet}.}
+\item{...}{Other arguments that can be passed to the function \code{prioritylasso}.}
 }
 \value{
-object of class \code{prioritylasso} with the following elements. If these elements are lists, they contain the results for each penalized block of the best result.
+object of class \code{cvm_prioritylasso} with the following elements. If these elements are lists, they contain the results for each penalized block of the best result.
 \describe{
 \item{\code{lambda.ind}}{list with indices of lambda for \code{lambda.type}.}
 \item{\code{lambda.type}}{type of lambda which is used for the predictions.}
@@ -66,6 +66,7 @@ object of class \code{prioritylasso} with the following elements. If these eleme
 \item{\code{block1unpen}}{if \code{block1.penalization = FALSE}, the results of either the fitted \code{glm} or \code{coxph} object.}
 \item{\code{best.blocks}}{character vector with the indices of the best block specification.}
 \item{\code{best.max.coef}}{vector with the number of maximal coefficients corresponding to \code{best.blocks}.}
+\item{\code{best.model}}{complete \code{prioritylasso} model of the best solution.}
 \item{\code{coefficients}}{coefficients according to the results obtained with \code{best.blocks}.}
 \item{\code{call}}{the function call.}
 }

--- a/man/cvm_prioritylasso.Rd
+++ b/man/cvm_prioritylasso.Rd
@@ -65,6 +65,7 @@ object of class \code{cvm_prioritylasso} with the following elements. If these e
 \item{\code{name}}{a text string indicating type of measure.}
 \item{\code{block1unpen}}{if \code{block1.penalization = FALSE}, the results of either the fitted \code{glm} or \code{coxph} object.}
 \item{\code{best.blocks}}{character vector with the indices of the best block specification.}
+\item{\code{best.blocks.indices}}{list with the indices of the best block specification ordered by best to worst.}
 \item{\code{best.max.coef}}{vector with the number of maximal coefficients corresponding to \code{best.blocks}.}
 \item{\code{best.model}}{complete \code{prioritylasso} model of the best solution.}
 \item{\code{coefficients}}{coefficients according to the results obtained with \code{best.blocks}.}

--- a/man/cvm_prioritylasso.Rd
+++ b/man/cvm_prioritylasso.Rd
@@ -23,7 +23,7 @@ cvm_prioritylasso(
 )
 }
 \arguments{
-\item{X}{a (nxp) matrix or data frame of predictors with observations in rows and predictors in columns.}
+\item{X}{a (nxp) matrix of predictors with observations in rows and predictors in columns.}
 
 \item{Y}{n-vector giving the value of the response (either continuous, numeric-binary 0/1, or \code{Surv} object).}
 
@@ -31,7 +31,7 @@ cvm_prioritylasso(
 
 \item{family}{should be "gaussian" for continuous \code{Y}, "binomial" for binary \code{Y}, "cox" for \code{Y} of type \code{Surv}.}
 
-\item{type.measure}{The accuracy/error measure computed in cross-validation. It should be "class" (classification error) or "auc" (area under the ROC curve) if \code{family="binomial"}, "mse" (mean squared error) if \code{family="gaussian"} and "deviance" if \code{family="cox"} which uses the partial-likelihood.}
+\item{type.measure}{accuracy/error measure computed in cross-validation. It should be "class" (classification error) or "auc" (area under the ROC curve) if \code{family="binomial"}, "mse" (mean squared error) if \code{family="gaussian"} and "deviance" if \code{family="cox"} which uses the partial-likelihood.}
 
 \item{blocks.list}{list of the format \code{list(list(bp1=...,bp2=...,), list(bp1=,...,bp2=...,), ...)}. For the specification of the entries, see \code{\link[prioritylasso]{prioritylasso}}.}
 
@@ -39,7 +39,7 @@ cvm_prioritylasso(
 
 \item{block1.penalization}{whether the first block should be penalized. Default is TRUE.}
 
-\item{lambda.type}{specifies the value of lambda used for the predictions. \code{lambda.min} gives lambda with minimum cross-validated errors. \code{lambda.1se} gives the largest value of lambda such that error is within 1 standard error of the minimum. Note that \code{lambda.1se} can only be chosen without restrictions of \code{max.coef}.}
+\item{lambda.type}{specifies the value of lambda used for the predictions. \code{lambda.min} gives lambda with minimum cross-validated errors. \code{lambda.1se} gives the largest value of lambda such that the error is within 1 standard error of the minimum. Note that \code{lambda.1se} can only be chosen without restrictions of \code{max.coef}.}
 
 \item{standardize}{logical, whether the predictors should be standardized or not. Default is TRUE.}
 
@@ -51,7 +51,7 @@ cvm_prioritylasso(
 
 \item{cvoffsetnfolds}{the number of folds in the CV procedure that is performed to estimate the offsets. Default is 10. Only relevant if \code{cvoffset=TRUE}.}
 
-\item{...}{Other arguments that can be passed to the function \code{prioritylasso}.}
+\item{...}{other arguments that can be passed to the function \code{prioritylasso}.}
 }
 \value{
 object of class \code{cvm_prioritylasso} with the following elements. If these elements are lists, they contain the results for each penalized block of the best result.

--- a/tests/testthat/test-cvmpl.R
+++ b/tests/testthat/test-cvmpl.R
@@ -96,7 +96,9 @@ test_that("cvm_prioritylasso contains the correct return elements", {
   expect_equal(names(cvm_miss), c("lambda.ind", "lambda.type", "lambda.min",
                                   "min.cvm", "nzero", "glmnet.fit",
                                   "name", "block1unpen", "best.blocks",
+                                  "best.blocks.indices",
                                   "best.max.coef", "best.model","coefficients",
                                   "call"))
   expect_s3_class(cvm_miss[["best.model"]], "prioritylasso")
+  expect_type(cvm_miss[["best.blocks.indices"]], "list")
 })

--- a/tests/testthat/test-cvmpl.R
+++ b/tests/testthat/test-cvmpl.R
@@ -1,21 +1,21 @@
 # gaussian
 cvm_pl1 <- cvm_prioritylasso(X = matrix(rnorm(50*500),50,500), Y = rnorm(50), family = "gaussian", type.measure = "mse",
-                        blocks.list = list(list(block1=1:75,block2=76:200, block3=201:500), list(1:75, 201:500, 76:200)),
-                        block1.penalization = TRUE, lambda.type = "lambda.min", standardize = TRUE, nfolds = 5)
+                             blocks.list = list(list(block1=1:75,block2=76:200, block3=201:500), list(1:75, 201:500, 76:200)),
+                             block1.penalization = TRUE, lambda.type = "lambda.min", standardize = TRUE, nfolds = 5)
 
 
 cvm_pl1a <- cvm_prioritylasso(X = matrix(rnorm(50*500),50,500), Y = rnorm(50), family = "gaussian", type.measure = "mse",
-                             blocks.list = list(list(block1=1:75,block2=76:200, block3=201:500), list(1:75, 201:500, 76:200)),
-                             max.coef.list = list(c(10,5,7), c(10,7,3)),
-                             block1.penalization = TRUE, lambda.type = "lambda.min", standardize = TRUE, nfolds = 5)
+                              blocks.list = list(list(block1=1:75,block2=76:200, block3=201:500), list(1:75, 201:500, 76:200)),
+                              max.coef.list = list(c(10,5,7), c(10,7,3)),
+                              block1.penalization = TRUE, lambda.type = "lambda.min", standardize = TRUE, nfolds = 5)
 
 
 # binomial
 cvm_pl2 <- cvm_prioritylasso(X = matrix(rnorm(50*500),50,500), Y = rbinom(n=50, size=1, prob=0.5), family = "binomial",
-                         type.measure = "auc", blocks.list = list(list(block1=1:75,block2=76:200, block3=201:500),
-                                                             list(1:75, 201:500, 76:200)),
-                         block1.penalization = TRUE, lambda.type = "lambda.min",
-                         standardize = TRUE, nfolds = 5)
+                             type.measure = "auc", blocks.list = list(list(block1=1:75,block2=76:200, block3=201:500),
+                                                                      list(1:75, 201:500, 76:200)),
+                             block1.penalization = TRUE, lambda.type = "lambda.min",
+                             standardize = TRUE, nfolds = 5)
 
 
 
@@ -33,43 +33,70 @@ y <- Surv(ty, 1-tcens)
 blocks <- list(list(block1=1:20, block2=21:200, block3=201:300), list(1:20, 201:300, 21:200))
 
 cvm_pl3 <- cvm_prioritylasso(x, y, family = "cox", type.measure = "deviance", blocks.list = blocks,
-                     block1.penalization = FALSE,
-                     lambda.type = "lambda.min", standardize = TRUE, nfolds = 5)
+                             block1.penalization = FALSE,
+                             lambda.type = "lambda.min", standardize = TRUE, nfolds = 5)
 
-
-
-library(testthat)
+# missingness
+# -> checks that further arguments can be passed from cvm_prioritylasso to
+# prioritylasso
+set.seed(1234)
+x_data <- matrix(rnorm(50*500),50,500)
+x_data_miss_b123 <- x_data
+x_data_miss_b123[30:40, 1:200] <- NA
+x_data_miss_b123[41:45, 201:500] <- NA
+set.seed(1234)
+cvm_miss <- suppressWarnings(cvm_prioritylasso(
+  X = x_data_miss_b123, Y = rnorm(50),
+  family = "gaussian",
+  type.measure = "mse",
+  blocks.list = list(list(block1=1:75, block2=76:200, block3=201:500),
+                     list(block1=76:200, block2=1:75, block3=201:500),
+                     list(block1=201:500, block2=1:75, block3=76:200)),
+  block1.penalization = TRUE,
+  lambda.type = "lambda.1se",
+  standardize = TRUE,
+  nfolds = 5,
+  mcontrol = missing.control(handle.missingdata = "impute.offset",
+                             impute.offset.cases = "available.cases")))
 
 test_that("testing error messages", {
-
+  
   expect_that(cvm_prioritylasso(X = matrix(rnorm(50*500),50,500), Y = rnorm(50), family = "gaussian", type.measure = "mse",
                                 blocks.list = list(list(1:75, 76:200, 201:500),list(1:75, 201:500)),
                                 block1.penalization = TRUE, lambda.type = "lambda.min", standardize = TRUE, nfolds = 5),
               throws_error("Each predictor should be included in exactly one block."))
-
+  
   expect_that(cvm_prioritylasso(X = matrix(rnorm(50*500),50,500), Y = rnorm(50), family = "gaussian", type.measure = "mse",
                                 blocks.list = list(list(block1=1:75,block2=76:200, block3=201:500), list(1:75, 201:500, 76:200)),
                                 max.coef.list = list(c(5,6,7)),
                                 block1.penalization = TRUE, lambda.type = "lambda.min", standardize = TRUE, nfolds = 5),
               throws_error("blocks.list and max.coef.list must have the same length."))
-
-
+  
+  
   expect_that(cvm_prioritylasso(X = matrix(rnorm(50*500),50,500), Y = rnorm(50), family = "gaussian", type.measure = "mse",
                                 blocks = list(list(block1=1:75,block2=76:200, block3=201:500), list(1:75, 76:500)),
                                 max.coef.list = list(c(5,6,7), c(8,9,10)),
                                 block1.penalization = TRUE, lambda.type = "lambda.min", standardize = TRUE, nfolds = 5),
               throws_error("blocks.list and the entries of max.coef.list must have the same length."))
-
-
+  
+  
 })
 
 test_that("testing cvm_prioritylasso", {
-
+  
   expect_that(length(cvm_pl1$best.blocks), testthat::equals(3))
   expect_match(cvm_pl2$name, "AUC")
-  expect_that(cvm_pl3, is_a("prioritylasso"))
+  expect_that(cvm_pl3, is_a("cvm_prioritylasso"))
   expect_true(cvm_pl1a$nzero[[1]] <= 10)
   expect_true(sum(unlist(cvm_pl1a$nzero)) <= 22)
-
+  
 })
 
+test_that("cvm_prioritylasso contains the correct return elements", {
+  expect_equal(names(cvm_miss), c("lambda.ind", "lambda.type", "lambda.min",
+                                  "min.cvm", "nzero", "glmnet.fit",
+                                  "name", "block1unpen", "best.blocks",
+                                  "best.max.coef", "best.model","coefficients",
+                                  "call"))
+  expect_s3_class(cvm_miss[["best.model"]], "prioritylasso")
+})


### PR DESCRIPTION
- add the following return values:
   - the complete model object of the best solution
   - the indices of the blocks in the best block order
- make the return object of class `cvm_prioritylasso` instead of `prioritylasso`
- add tests for this
- simplify documentation